### PR TITLE
Support for Linux arm and clean up

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,18 +11,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: false
-      max-parallel: 4
+      fail-fast: true
+      max-parallel: 6
       matrix:
-        os: [ ubuntu-24.04, ubuntu-22.04 ]
+        # Test all options
+        os: [ ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm ]
         formula: [ metanorma ]
         experimental: [ false ]
         include:
+          # One x64 and one arm enough?
           - os: ubuntu-24.04
             formula: metanorma-dev
             executable: metanorma
             experimental: true
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             formula: metanorma-dev
             executable: metanorma
             experimental: true
@@ -52,11 +54,11 @@ jobs:
 
       - run: brew install --build-from-source --verbose --include-test --formula Formula/${{ matrix.formula }}.rb
         # To ignore potential: The `brew link` step did not complete successfully
-        continue-on-error: true
+        # continue-on-error: true
 
       - run: which ${{ matrix.executable || matrix.formula }}
 
       - run: brew test --verbose ${{ matrix.formula }}
-        continue-on-error: true # Because ietf test fails anyway
+        # continue-on-error: true # Because ietf test fails anyway
 
       - run: brew uninstall ${{ matrix.formula }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,12 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # macos-13: intel; macos-14, macos-15: arm64
         os: [ macos-15, macos-14, macos-13 ]
         formula: [ metanorma ]
         experimental: [ false ]
         include:
           - formula: metanorma-dev
             os: macos-15
+            experimental: true
+            executable: metanorma
+          - formula: metanorma-dev
+            os: macos-13
             experimental: true
             executable: metanorma
 
@@ -44,15 +49,18 @@ jobs:
       - run: |
           brew install --build-from-source --verbose --formula Formula/${{ matrix.formula }}.rb
         # To ignore potential: The `brew link` step did not complete successfully
-        continue-on-error: true
+        #continue-on-error: true
 
       - run: brew audit --strict --formula ${{ matrix.formula }}
         # To ignore potential: GitHub API Error: API rate limit exceeded for
-        continue-on-error: true
+        #  Files were found with references to the Homebrew shims directory.
+        #    The offending files are:
+        #      libexec/gems/sqlite3-1.7.3/ext/sqlite3/tmp/arm64-apple-darwin24.4.0/ports/sqlite3/3.45.2/sqlite-autoconf-3450200/config.log
+        continue-on-error: ${{ matrix.experimental }}
 
       - run: which ${{ matrix.executable || matrix.formula }}
 
       - run: brew test --verbose ${{ matrix.formula }}
-        continue-on-error: true # Because ietf test fails anyway
+        #continue-on-error: true # Because ietf test fails anyway
 
       - run: brew uninstall ${{ matrix.formula }}

--- a/Formula/metanorma-dev.rb
+++ b/Formula/metanorma-dev.rb
@@ -104,13 +104,13 @@ class MetanormaDev < Formula
            "--agree-to-terms"
     assert_predicate testpath / "test-csa.html", :exist?
 
-    (testpath / "test-ietf.adoc").write(ietf_test_doc)
-    system bin / "metanorma", testpath / "test-ietf.adoc", "--agree-to-terms"
-    assert_predicate testpath / "test-ietf.html", :exist?
+    #(testpath / "test-ietf.adoc").write(ietf_test_doc)
+    #system bin / "metanorma", testpath / "test-ietf.adoc", "--agree-to-terms"
+    #assert_predicate testpath / "test-ietf.html", :exist?
 
-    (testpath / "test-standoc.adoc").write(metanorma_latexml_test_doc)
-    system bin / "metanorma", "--type", "standoc", "--extensions", "xml",
-           testpath / "test-standoc.adoc", "--agree-to-terms"
-    assert_predicate testpath / "test-standoc.xml", :exist?
+    #(testpath / "test-standoc.adoc").write(metanorma_latexml_test_doc)
+    #system bin / "metanorma", "--type", "standoc", "--extensions", "xml",
+    #       testpath / "test-standoc.adoc", "--agree-to-terms"
+    #assert_predicate testpath / "test-standoc.xml", :exist?
   end
 end

--- a/Formula/metanorma.rb
+++ b/Formula/metanorma.rb
@@ -41,11 +41,20 @@ class Metanorma < Formula
   end
 
   if OS.linux?
-    resource "packed-mn" do
-      # > formula-set-version.sh packed-mn-linux #
-      url "https://github.com/metanorma/packed-mn/releases/download/v1.12.5/metanorma-linux-x86_64.tgz"
-      sha256 "652d32fb6433f75f38960f960ea300fe77fd68f8839c09c9d3d73e0dfe712745"
-      # < formula-set-version.sh packed-mn-linux #
+    if Hardware::CPU.arm?
+      resource "packed-mn" do
+        # > formula-set-version.sh packed-mn-linux-arm #
+        url "https://github.com/metanorma/packed-mn/releases/download/v1.12.5/metanorma-linux-aarch64.tgz"
+        sha256 "23beca72bf87728360201c078cbdae0df8b576e24b1469b8b6b5a76dfc3e938e"
+        # < formula-set-version.sh packed-mn-linux-arm #
+      end
+    else # assume Hardware::CPU.intel
+      resource "packed-mn" do
+        # > formula-set-version.sh packed-mn-linux #
+        url "https://github.com/metanorma/packed-mn/releases/download/v1.12.5/metanorma-linux-x86_64.tgz"
+        sha256 "652d32fb6433f75f38960f960ea300fe77fd68f8839c09c9d3d73e0dfe712745"
+        # < formula-set-version.sh packed-mn-linux #
+      end
     end
   end
 
@@ -53,7 +62,7 @@ class Metanorma < Formula
     platform = if OS.mac?
                  Hardware::CPU.arm? ? "darwin-arm64" : "darwin-x86_64"
                elsif OS.linux?
-                 "linux-x86_64"
+                 Hardware::CPU.arm? ? "linux-aarch64" : "linux-x86_64"
                end
 
     resource("packed-mn").stage do
@@ -130,13 +139,13 @@ class Metanorma < Formula
     assert_predicate testpath / "test-csa.pdf", :exist?
     assert_predicate testpath / "test-csa.html", :exist?
 
-    (testpath / "test-ietf.adoc").write(ietf_test_doc)
-    system bin / "metanorma", testpath / "test-ietf.adoc", "--agree-to-terms"
-    assert_predicate testpath / "test-ietf.html", :exist?
+    #(testpath / "test-ietf.adoc").write(ietf_test_doc)
+    #system bin / "metanorma", testpath / "test-ietf.adoc", "--agree-to-terms"
+    #assert_predicate testpath / "test-ietf.html", :exist?
 
-    (testpath / "test-standoc.adoc").write(latexml_test_doc)
-    system bin / "metanorma", "--type", "standoc", "--extensions", "xml",
-           testpath / "test-standoc.adoc", "--agree-to-terms"
-    assert_predicate testpath / "test-standoc.xml", :exist?
+    #(testpath / "test-standoc.adoc").write(latexml_test_doc)
+    #system bin / "metanorma", "--type", "standoc", "--extensions", "xml",
+    #       testpath / "test-standoc.adoc", "--agree-to-terms"
+    #assert_predicate testpath / "test-standoc.xml", :exist?
   end
 end

--- a/formula-set-version.sh
+++ b/formula-set-version.sh
@@ -38,7 +38,14 @@ PACKED_MN_LINUX_SHA256_URL="${PACKED_MN_LINUX_URL}.sha256.txt"
 PACKED_MN_LINUX_SHA256=$(curl -sL ${PACKED_MN_LINUX_SHA256_URL} | cut -d ' ' -f1)
 REPLACE_MARKER_BEGIN="# > formula-set-version.sh packed-mn-linux #"
 REPLACE_MARKER_END="# < formula-set-version.sh packed-mn-linux #"
-${SED} -i "/${REPLACE_MARKER_BEGIN}/,/${REPLACE_MARKER_END}/c\      ${REPLACE_MARKER_BEGIN}\n      url \"${PACKED_MN_LINUX_URL}\"\n      sha256 \"${PACKED_MN_LINUX_SHA256}\"\n      ${REPLACE_MARKER_END}" Formula/metanorma.rb
+${SED} -i "/${REPLACE_MARKER_BEGIN}/,/${REPLACE_MARKER_END}/c\        ${REPLACE_MARKER_BEGIN}\n        url \"${PACKED_MN_LINUX_URL}\"\n        sha256 \"${PACKED_MN_LINUX_SHA256}\"\n        ${REPLACE_MARKER_END}" Formula/metanorma.rb
+
+PACKED_MN_LINUX_ARM_URL="https://github.com/metanorma/packed-mn/releases/download/v${MN_CLI_GEM_VERSION}/metanorma-linux-aarch64.tgz"
+PACKED_MN_LINUX_ARM_SHA256_URL="${PACKED_MN_LINUX_ARM_URL}.sha256.txt"
+PACKED_MN_LINUX_ARM_SHA256=$(curl -sL ${PACKED_MN_LINUX_ARM_SHA256_URL} | cut -d ' ' -f1)
+REPLACE_MARKER_BEGIN="# > formula-set-version.sh packed-mn-linux-arm #"
+REPLACE_MARKER_END="# < formula-set-version.sh packed-mn-linux-arm #"
+${SED} -i "/${REPLACE_MARKER_BEGIN}/,/${REPLACE_MARKER_END}/c\        ${REPLACE_MARKER_BEGIN}\n        url \"${PACKED_MN_LINUX_ARM_URL}\"\n        sha256 \"${PACKED_MN_LINUX_ARM_SHA256}\"\n        ${REPLACE_MARKER_END}" Formula/metanorma.rb
 
 if [ "${PACKED_MN_LINUX_SHA256}" = "Not" ]; then
 	echo "Skip test bump because Linux packed-mn binary is not compiled yet"


### PR DESCRIPTION
https://github.com/metanorma/homebrew-metanorma/issues/88

- Add Metanorma Linux arm binaries
- Test on Linux arm runners
- Test on all runner types
- Comment out "continue-on-error
- Disable failing tests ("test-ietf.adoc", "test-standoc.adoc") only
- Ignore audit error for metanorma-dev